### PR TITLE
Add basic support for Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,48 +1,60 @@
 # php-docker Beta
+
 These files provide Docker support with a basic PHP application.
 The focus is to run OctoberCMS in an Apache environment.
 
 It provide an APACHE server runing PHP (port 8080) - MySql 5.7 - PHPMyAdmin (port 8081)
 
 ## Versions
+
 Choose between `php5.6-mcrypt`, `php7.2-mcrypt` or `php7.3`, then copy those files at the root of your project folder.
 If you are using an Apple Silicon Mac, you can use the files in `apple-silicon`. Support for mailhog has been temporarily removed until a solution has been found.
 
 ## Building
+
 Build and run the Docker image:
-```
+
+```bash
 docker-compose up --build
 ```
 
 Or, just build the Docker image:
-```
+
+```bash
 docker build -f Dockerfile -t php-alone .
 ```
 
 When your Docker image has been built, run:
-```
+
+```bash
 docker-compose up
 ```
 
 ## MySQL settings
+
 Uncomment lines 30-31 and 51-52 in `docker-compose.yaml` to enable persistent mysql data.
 
 Docker will create the volume for you in the `/var/lib/docker/volumes` folder. This volume persist as long as you are not typing:
-```
+
+```bash
 docker-compose down -v
 ```
 
 ## PHPMyAdmin settings
+
 Uncomment lines 41-42 in `docker-compose.yaml` to skip phpmyadmin login screen.
 
 ## Mail settings
+
 To use the mail tester, change the "Mail method" to SMTP
-```
+
+```text
 SMTP Address: mailhog
 SMTP Port: 1025
 SMTP Encryption: No encryption
 No username or password, see screenshot.
 ```
+
 ![OctoberCMS Screenshot](https://github.com/TheJackMachine/php-docker/blob/master/mailsettings.jpg)
 
 ## To test on Windows and Mac

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ It provide an APACHE server runing PHP (port 8080) - MySql 5.7 - PHPMyAdmin (por
 
 ## Versions
 Choose between `php5.6-mcrypt`, `php7.2-mcrypt` or `php7.3`, then copy those files at the root of your project folder.
+If you are using an Apple Silicon Mac, you can use the files in `apple-silicon`. Support for mailhog has been temporarily removed until a solution has been found.
 
 ## Building
 Build and run the Docker image:

--- a/apple-silicon/php5.6-mcrypt/Dockerfile
+++ b/apple-silicon/php5.6-mcrypt/Dockerfile
@@ -1,0 +1,59 @@
+FROM php:5.6-apache
+
+RUN set -ex
+
+# ADD wget
+RUN apt-get update
+RUN  apt-get install -y wget
+
+
+#ADD composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+RUN EXPECTED_CHECKSUM="$(wget -q -O - https://composer.github.io/installer.sig)"
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+RUN ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+RUN	if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]; \
+	then >&2 echo 'ERROR: Composer Invalid installer checksum'; \
+		rm composer-setup.php; \
+		exit 1; \
+	fi
+
+RUN php composer-setup.php --quiet
+RUN php -r "unlink('composer-setup.php');"
+RUN mv composer.phar /usr/local/bin/composer
+
+# ADD PHP Extension
+RUN apt-get install -y --no-install-recommends libfreetype6-dev \
+		libjpeg-dev \
+		libmagickwand-dev \
+		libpng-dev \
+		libzip-dev \
+		libmcrypt-dev
+
+RUN docker-php-ext-install mcrypt
+RUN docker-php-ext-enable mcrypt
+
+RUN	docker-php-ext-configure gd --with-freetype-dir=/usr --with-jpeg-dir=/usr --with-png-dir=/usr
+RUN docker-php-ext-install gd
+
+RUN docker-php-ext-configure zip --with-libzip=/usr/include
+RUN docker-php-ext-install zip
+
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install exif
+RUN docker-php-ext-install bcmath
+
+# COPY ./testing /var/www/html
+# COPY vhost.conf /etc/apache2/sites-available/000-default.conf
+RUN chown -R www-data:www-data /var/www/html && a2enmod rewrite
+
+# CHANGE INDEX.PHP FILE LOCATION BELOW
+ENV APACHE_DOCUMENT_ROOT=/var/www/html/public_html
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
+RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+RUN apt-get install --no-install-recommends --assume-yes --quiet ca-certificates curl git &&\
+    rm -rf /var/lib/apt/lists/*
+RUN curl -Lsf 'https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz' | tar -C '/usr/local' -xvzf -
+ENV PATH /usr/local/go/bin:$PATH

--- a/apple-silicon/php5.6-mcrypt/docker-compose.yaml
+++ b/apple-silicon/php5.6-mcrypt/docker-compose.yaml
@@ -1,0 +1,48 @@
+version: '3'
+services:
+
+  php7:
+    hostname: docker
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: php-alone
+    ports:
+      - "8080:80"
+    volumes:
+      - .:/var/www/html
+    links:
+      - mysql
+    environment:
+        DB_HOST: mysql
+        DB_DATABASE: docker
+        DB_USERNAME: docker
+        DB_PASSWORD: docker
+
+  mysql:
+    platform: linux/x86_64
+    image: mysql:5.7
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_DATABASE: docker
+      MYSQL_USER: docker
+      MYSQL_PASSWORD: docker
+      MYSQL_ROOT_PASSWORD: docker
+    volumes: # Comment / Uncomment for persistent mysql data
+    - my-datavolume:/var/lib/mysql # Comment / Uncomment for persistent mysql data
+
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin:latest
+    links:
+    - mysql
+    ports:
+    - "8081:80"
+    environment:
+      PMA_HOST: mysql
+      PMA_USER: docker # Comment / Uncomment for automatic login
+      PMA_PASSWORD: docker # Comment / Uncomment for automatic login
+      UPLOAD_LIMIT: 256M
+
+volumes: # Comment / Uncomment for persistent mysql data
+  my-datavolume: # Comment / Uncomment for persistent mysql data

--- a/apple-silicon/php7.2-mcrypt/Dockerfile
+++ b/apple-silicon/php7.2-mcrypt/Dockerfile
@@ -1,0 +1,59 @@
+FROM php:7.2-apache
+
+RUN set -ex
+
+# ADD wget
+RUN apt-get update
+RUN  apt-get install -y wget
+
+
+#ADD composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+RUN EXPECTED_CHECKSUM="$(wget -q -O - https://composer.github.io/installer.sig)"
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+RUN ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+RUN	if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]; \
+	then >&2 echo 'ERROR: Composer Invalid installer checksum'; \
+		rm composer-setup.php; \
+		exit 1; \
+	fi
+
+RUN php composer-setup.php --quiet
+RUN php -r "unlink('composer-setup.php');"
+RUN mv composer.phar /usr/local/bin/composer
+
+# ADD PHP Extension
+RUN apt-get install -y --no-install-recommends libfreetype6-dev \
+		libjpeg-dev \
+		libmagickwand-dev \
+		libpng-dev \
+		libzip-dev \
+		libmcrypt-dev
+
+RUN pecl install mcrypt-1.0.1
+RUN docker-php-ext-enable mcrypt
+
+RUN	docker-php-ext-configure gd --with-freetype-dir=/usr --with-jpeg-dir=/usr --with-png-dir=/usr
+RUN docker-php-ext-install gd
+
+RUN docker-php-ext-configure zip --with-libzip=/usr/include
+RUN docker-php-ext-install zip
+
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install exif
+RUN docker-php-ext-install bcmath
+
+# COPY ./testing /var/www/html
+# COPY vhost.conf /etc/apache2/sites-available/000-default.conf
+RUN chown -R www-data:www-data /var/www/html && a2enmod rewrite
+
+# CHANGE INDEX.PHP FILE LOCATION BELOW
+ENV APACHE_DOCUMENT_ROOT=/var/www/html/public_html
+RUN sed -ri -e 's!/var/www/html!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/sites-available/*.conf
+RUN sed -ri -e 's!/var/www/!${APACHE_DOCUMENT_ROOT}!g' /etc/apache2/apache2.conf /etc/apache2/conf-available/*.conf
+
+RUN apt-get install --no-install-recommends --assume-yes --quiet ca-certificates curl git &&\
+    rm -rf /var/lib/apt/lists/*
+RUN curl -Lsf 'https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz' | tar -C '/usr/local' -xvzf -
+ENV PATH /usr/local/go/bin:$PATH

--- a/apple-silicon/php7.2-mcrypt/docker-compose.yaml
+++ b/apple-silicon/php7.2-mcrypt/docker-compose.yaml
@@ -1,0 +1,48 @@
+version: '3'
+services:
+
+  php7:
+    hostname: docker
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: php-alone
+    ports:
+      - "8080:80"
+    volumes:
+      - .:/var/www/html
+    links:
+      - mysql
+    environment:
+        DB_HOST: mysql
+        DB_DATABASE: docker
+        DB_USERNAME: docker
+        DB_PASSWORD: docker
+
+  mysql:
+    platform: linux/x86_64
+    image: mysql:5.7
+    ports:
+      - 3306:3306
+    environment:
+      MYSQL_DATABASE: docker
+      MYSQL_USER: docker
+      MYSQL_PASSWORD: docker
+      MYSQL_ROOT_PASSWORD: docker
+    volumes: # Comment / Uncomment for persistent mysql data
+    - my-datavolume:/var/lib/mysql # Comment / Uncomment for persistent mysql data
+
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin:latest
+    links:
+    - mysql
+    ports:
+    - "8081:80"
+    environment:
+      PMA_HOST: mysql
+      PMA_USER: docker # Comment / Uncomment for automatic login
+      PMA_PASSWORD: docker # Comment / Uncomment for automatic login
+      UPLOAD_LIMIT: 256M
+
+volumes: # Comment / Uncomment for persistent mysql data
+  my-datavolume: # Comment / Uncomment for persistent mysql data

--- a/apple-silicon/php7.3/Dockerfile
+++ b/apple-silicon/php7.3/Dockerfile
@@ -1,0 +1,50 @@
+FROM php:7.3-apache
+
+RUN set -ex
+
+# ADD wget
+RUN apt-get update
+RUN  apt-get install -y wget
+
+
+#ADD composer
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+RUN EXPECTED_CHECKSUM="$(wget -q -O - https://composer.github.io/installer.sig)"
+RUN php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+RUN ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
+
+RUN	if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]; \
+	then >&2 echo 'ERROR: Composer Invalid installer checksum'; \
+		rm composer-setup.php; \
+		exit 1; \
+	fi
+
+RUN php composer-setup.php --quiet
+RUN php -r "unlink('composer-setup.php');"
+RUN mv composer.phar /usr/local/bin/composer
+
+# ADD PHP Extension
+RUN apt-get install -y --no-install-recommends libfreetype6-dev \
+		libjpeg-dev \
+		libmagickwand-dev \
+		libpng-dev \
+		libzip-dev
+
+RUN	docker-php-ext-configure gd --with-freetype-dir=/usr --with-jpeg-dir=/usr --with-png-dir=/usr
+RUN docker-php-ext-install gd
+
+RUN docker-php-ext-configure zip --with-libzip=/usr/include
+RUN docker-php-ext-install zip
+
+RUN docker-php-ext-install pdo_mysql
+RUN docker-php-ext-install exif
+RUN docker-php-ext-install bcmath
+
+# COPY ./testing /var/www/html
+# COPY vhost.conf /etc/apache2/sites-available/000-default.conf
+RUN chown -R www-data:www-data /var/www/html && a2enmod rewrite
+
+RUN apt-get install --no-install-recommends --assume-yes --quiet ca-certificates curl git &&\
+    rm -rf /var/lib/apt/lists/*
+RUN curl -Lsf 'https://storage.googleapis.com/golang/go1.8.3.linux-amd64.tar.gz' | tar -C '/usr/local' -xvzf -
+ENV PATH /usr/local/go/bin:$PATH

--- a/apple-silicon/php7.3/docker-compose.yaml
+++ b/apple-silicon/php7.3/docker-compose.yaml
@@ -1,0 +1,48 @@
+version: '3'
+services:
+
+  php7:
+    hostname: docker
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: php-alone
+    ports:
+    - "8080:80"
+    volumes:
+    - .:/var/www/html
+    links:
+    - mysql
+    environment:
+      DB_HOST: mysql
+      DB_DATABASE: docker
+      DB_USERNAME: docker
+      DB_PASSWORD: docker
+
+  mysql:
+    platform: linux/x86_64
+    image: mysql:5.7
+    ports:
+    - 3306:3306
+    environment:
+      MYSQL_DATABASE: docker
+      MYSQL_USER: docker
+      MYSQL_PASSWORD: docker
+      MYSQL_ROOT_PASSWORD: docker
+    volumes: # Comment / Uncomment for persistent mysql data
+    - my-datavolume:/var/lib/mysql # Comment / Uncomment for persistent mysql data
+
+  phpmyadmin:
+    image: phpmyadmin/phpmyadmin:latest
+    links:
+    - mysql
+    ports:
+    - "8081:80"
+    environment:
+      PMA_HOST: mysql
+      PMA_USER: docker # Comment / Uncomment for automatic login
+      PMA_PASSWORD: docker # Comment / Uncomment for automatic login
+      UPLOAD_LIMIT: 1000M
+
+volumes: # Comment / Uncomment for persistent mysql data
+  my-datavolume: # Comment / Uncomment for persistent mysql data


### PR DESCRIPTION
- Temporarily remove Mailhog support until a solution has been found.
- Untested with PHP 5.6/7.2 mcrypt but it should work.
- Fix markdown violation in README.

TODO later: Find a way to have files for both Apple Silicon & Intel support in same project, or in the same files if possible.